### PR TITLE
Temporary Fix Truffle to Weed bug

### DIFF
--- a/AnimalSitter/config.json
+++ b/AnimalSitter/config.json
@@ -9,7 +9,7 @@
   "CostPerAction": 25,
   "WhoChecks": "spouse",
   "EnableMessages": true,
-  "TakeTrufflesFromPigs": true,
+  "TakeTrufflesFromPigs": false,
   "BypassInventory": false,
   "ChestCoords": "73, 14",
   "ChestDefs": ""

--- a/AnimalSitter/manifest.json
+++ b/AnimalSitter/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "Animal Sitter LTS",
   "Author": "oliver",
-  "Version": "2.0.3",
+  "Version": "2.0.4",
   "Description": "Long Term Support Mod Version for Animal Sitter Mod. Let someone else pet all those pesky animals!",
   "UniqueID": "oliver.AnimalSitterLTS",
   "EntryDll": "AnimalSitter.dll",


### PR DESCRIPTION
This will fix #9 

Temp Solution: Disable `TakeTrufflesFromPigs` config. And detailed root cause here: https://github.com/WuZhuoran/Stardew_AnimalSitter/issues/9#issuecomment-2036461092

Will raise another issue and pull request to resolve this issue forever.