### PR TITLE
Feature: Add GenericModConfigMenu Support

### DIFF
--- a/AnimalSitter/AnimalSitter.cs
+++ b/AnimalSitter/AnimalSitter.cs
@@ -11,6 +11,8 @@ using StardewValley.Objects;
 using AnimalSitter.Common;
 using Object = StardewValley.Object;
 using Microsoft.Xna.Framework.Graphics;
+using AnimalSitter.Integrations.GenericModConfigMenu;
+using Microsoft.Xna.Framework.Input;
 
 namespace AnimalSitter
 {
@@ -80,6 +82,103 @@ namespace AnimalSitter
 
             helper.Events.GameLoop.SaveLoaded += this.OnSaveLoaded;
             helper.Events.Input.ButtonPressed += this.OnButtonPressed;
+            helper.Events.GameLoop.GameLaunched += this.OnGameLaunched;
+        }
+
+        /// <summary>Raised after the player loads a save slot.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event arguments.</param>
+        private void OnGameLaunched(object sender, GameLaunchedEventArgs e)
+        {
+            // get Generic Mod Config Menu's API (if it's installed)
+            var configMenu = this.Helper.ModRegistry.GetApi<IGenericModConfigMenuApi>("spacechase0.GenericModConfigMenu");
+            if (configMenu is null)
+                return;
+
+            // register mod
+            configMenu.Register(
+                mod: this.ModManifest,
+                reset: () => this.Config = new ModConfig(),
+                save: () => this.Helper.WriteConfig(this.Config)
+            );
+
+            configMenu.AddKeybind(mod: this.ModManifest,
+                name: () => "KeyBind",
+                tooltip: () => "The key that you press to tell your animal helper to get to work. This defaults to the 'O' key.",
+                getValue: () => SButtonExtensions.ToSButton((Keys)Enum.Parse(typeof(Keys), this.Config.KeyBind)),
+                setValue: value => this.Config.KeyBind = value.ToString());
+
+            configMenu.AddBoolOption(
+                mod: this.ModManifest,
+                name: () => "GrowUpEnabled",
+                tooltip: () => "This open tells your animal helper that you'd like them to use dark magic to instantly bring young animals up to the age where they can become contributing members of your farm. Default is false.",
+                getValue: () => this.Config.GrowUpEnabled,
+                setValue: value => this.Config.GrowUpEnabled = value
+            );
+
+            configMenu.AddBoolOption(
+                mod: this.ModManifest,
+                name: () => "MaxHappinessEnabled",
+                tooltip: () => "This option tells your animal helper that you don't care how long (or where) they have to pet your animals, but their job is not done until each animal's happiness is maxed. Default is false.",
+                getValue: () => this.Config.MaxHappinessEnabled,
+                setValue: value => this.Config.MaxHappinessEnabled = value
+            );
+
+            configMenu.AddBoolOption(
+                mod: this.ModManifest,
+                name: () => "MaxFullnessEnabled",
+                tooltip: () => "This option tells your animal helper to feed your animals. A full animal is a producing animal. Default is false.",
+                getValue: () => this.Config.MaxFullnessEnabled,
+                setValue: value => this.Config.MaxFullnessEnabled = value
+            );
+
+            configMenu.AddBoolOption(
+                mod: this.ModManifest,
+                name: () => "HarvestEnabled",
+                tooltip: () => "This tells your animal worker to harvest the animal drops. If you like doing this yourself, then set this to false.",
+                getValue: () => this.Config.HarvestEnabled,
+                setValue: value => this.Config.HarvestEnabled = value
+            );
+
+            configMenu.AddBoolOption(
+                mod: this.ModManifest,
+                name: () => "PettingEnabled",
+                tooltip: () => "This tells your animal worker that you want your animals petted. This is the whole reason I made this mod, so it defaults to true. So if you set this to \"false\", please keep it to yourself. If you enjoy petting each of your animals (because you don't have a hundred of them) then set it to false.",
+                getValue: () => this.Config.PettingEnabled,
+                setValue: value => this.Config.PettingEnabled = value
+            );
+
+            configMenu.AddBoolOption(
+                mod: this.ModManifest,
+                name: () => "MaxFriendshipEnabled",
+                tooltip: () => "This tells your animal worker whether they have to wear your 'you' mask, so that the affection of the animals is directed toward you, and not the help. Defaults to false.",
+                getValue: () => this.Config.MaxFriendshipEnabled,
+                setValue: value => this.Config.MaxFriendshipEnabled = value
+            );
+
+            configMenu.AddNumberOption(
+                mod: this.ModManifest,
+                name: () => "CostPerAction",
+                tooltip: () => "This is how much to charge per action per animal. There have been some suggestions around this option, and I do have plans to introduce a more complex pricing structure in the future, but for now just make sure this includes all services that you want the animal checker to perform, and average it out over the number of actions. Defaults to 25.",
+                getValue: () => this.Config.CostPerAction,
+                setValue: value => this.Config.CostPerAction = value
+                );
+
+            configMenu.AddBoolOption(
+                mod: this.ModManifest,
+                name: () => "EnableMessages",
+                tooltip: () => "This is whether to enable in-game messages and dialogues revolving around your animal checker. It defaults to true.",
+                getValue: () => this.Config.EnableMessages,
+                setValue: value => this.Config.EnableMessages = value
+            );
+
+            configMenu.AddBoolOption(
+                mod: this.ModManifest,
+                name: () => "TakeTrufflesFromPigs",
+                tooltip: () => "Whoever trainedm these pigs did an awful job, as they have a tendency to hide truffles. Where? I'm not exactly sure, but they've got 'em, trust me. With this option enabled, your farm helper will perform a TSA-approved body cavity search and find them. If you love the person who is doing your checking, or if you want your pigs to remain unviolated, or if you consider this cheating, then set it to false.",
+                getValue: () => this.Config.TakeTrufflesFromPigs,
+                setValue: value => this.Config.TakeTrufflesFromPigs = value
+            );
         }
 
 

--- a/AnimalSitter/AnimalSitter.csproj
+++ b/AnimalSitter/AnimalSitter.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Common\DialogueManager.cs" />
     <Compile Include="Framework\AnimalTasks.cs" />
     <Compile Include="Framework\ModConfig.cs" />
+    <Compile Include="Integrations\GenericModConfigMenu\IGenericModConfigMenuApi.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/AnimalSitter/Integrations/GenericModConfigMenu/IGenericModConfigMenuApi.cs
+++ b/AnimalSitter/Integrations/GenericModConfigMenu/IGenericModConfigMenuApi.cs
@@ -1,0 +1,177 @@
+﻿using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI;
+using StardewModdingAPI.Utilities;
+using StardewValley;
+
+namespace AnimalSitter.Integrations.GenericModConfigMenu
+{
+    /// <summary>The API which lets other mods add a config UI through Generic Mod Config Menu.</summary>
+    public interface IGenericModConfigMenuApi
+    {
+        /*********
+        ** Methods
+        *********/
+        /****
+        ** Must be called first
+        ****/
+        /// <summary>Register a mod whose config can be edited through the UI.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="reset">Reset the mod's config to its default values.</param>
+        /// <param name="save">Save the mod's current config to the <c>config.json</c> file.</param>
+        /// <param name="titleScreenOnly">Whether the options can only be edited from the title screen.</param>
+        /// <remarks>Each mod can only be registered once, unless it's deleted via <see cref="Unregister"/> before calling this again.</remarks>
+        void Register(IManifest mod, Action reset, Action save, bool titleScreenOnly = false);
+
+
+        /****
+        ** Basic options
+        ****/
+        /// <summary>Add a section title at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="text">The title text shown in the form.</param>
+        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the title, or <c>null</c> to disable the tooltip.</param>
+        void AddSectionTitle(IManifest mod, Func<string> text, Func<string> tooltip = null);
+
+        /// <summary>Add a paragraph of text at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="text">The paragraph text to display.</param>
+        void AddParagraph(IManifest mod, Func<string> text);
+
+        /// <summary>Add an image at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="texture">The image texture to display.</param>
+        /// <param name="texturePixelArea">The pixel area within the texture to display, or <c>null</c> to show the entire image.</param>
+        /// <param name="scale">The zoom factor to apply to the image.</param>
+        void AddImage(IManifest mod, Func<Texture2D> texture, Rectangle? texturePixelArea = null, int scale = Game1.pixelZoom);
+
+        /// <summary>Add a boolean option at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="getValue">Get the current value from the mod config.</param>
+        /// <param name="setValue">Set a new value in the mod config.</param>
+        /// <param name="name">The label text to show in the form.</param>
+        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field, or <c>null</c> to disable the tooltip.</param>
+        /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
+        void AddBoolOption(IManifest mod, Func<bool> getValue, Action<bool> setValue, Func<string> name, Func<string> tooltip = null, string fieldId = null);
+
+        /// <summary>Add an integer option at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="getValue">Get the current value from the mod config.</param>
+        /// <param name="setValue">Set a new value in the mod config.</param>
+        /// <param name="name">The label text to show in the form.</param>
+        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field, or <c>null</c> to disable the tooltip.</param>
+        /// <param name="min">The minimum allowed value, or <c>null</c> to allow any.</param>
+        /// <param name="max">The maximum allowed value, or <c>null</c> to allow any.</param>
+        /// <param name="interval">The interval of values that can be selected.</param>
+        /// <param name="formatValue">Get the display text to show for a value, or <c>null</c> to show the number as-is.</param>
+        /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
+        void AddNumberOption(IManifest mod, Func<int> getValue, Action<int> setValue, Func<string> name, Func<string> tooltip = null, int? min = null, int? max = null, int? interval = null, Func<int, string> formatValue = null, string fieldId = null);
+
+        /// <summary>Add a float option at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="getValue">Get the current value from the mod config.</param>
+        /// <param name="setValue">Set a new value in the mod config.</param>
+        /// <param name="name">The label text to show in the form.</param>
+        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field, or <c>null</c> to disable the tooltip.</param>
+        /// <param name="min">The minimum allowed value, or <c>null</c> to allow any.</param>
+        /// <param name="max">The maximum allowed value, or <c>null</c> to allow any.</param>
+        /// <param name="interval">The interval of values that can be selected.</param>
+        /// <param name="formatValue">Get the display text to show for a value, or <c>null</c> to show the number as-is.</param>
+        /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
+        void AddNumberOption(IManifest mod, Func<float> getValue, Action<float> setValue, Func<string> name, Func<string> tooltip = null, float? min = null, float? max = null, float? interval = null, Func<float, string> formatValue = null, string fieldId = null);
+
+        /// <summary>Add a string option at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="getValue">Get the current value from the mod config.</param>
+        /// <param name="setValue">Set a new value in the mod config.</param>
+        /// <param name="name">The label text to show in the form.</param>
+        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field, or <c>null</c> to disable the tooltip.</param>
+        /// <param name="allowedValues">The values that can be selected, or <c>null</c> to allow any.</param>
+        /// <param name="formatAllowedValue">Get the display text to show for a value from <paramref name="allowedValues"/>, or <c>null</c> to show the values as-is.</param>
+        /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
+        void AddTextOption(IManifest mod, Func<string> getValue, Action<string> setValue, Func<string> name, Func<string> tooltip = null, string[] allowedValues = null, Func<string, string> formatAllowedValue = null, string fieldId = null);
+
+        /// <summary>Add a key binding at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="getValue">Get the current value from the mod config.</param>
+        /// <param name="setValue">Set a new value in the mod config.</param>
+        /// <param name="name">The label text to show in the form.</param>
+        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field, or <c>null</c> to disable the tooltip.</param>
+        /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
+        void AddKeybind(IManifest mod, Func<SButton> getValue, Action<SButton> setValue, Func<string> name, Func<string> tooltip = null, string fieldId = null);
+
+        /// <summary>Add a key binding list at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="getValue">Get the current value from the mod config.</param>
+        /// <param name="setValue">Set a new value in the mod config.</param>
+        /// <param name="name">The label text to show in the form.</param>
+        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field, or <c>null</c> to disable the tooltip.</param>
+        /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
+        void AddKeybindList(IManifest mod, Func<KeybindList> getValue, Action<KeybindList> setValue, Func<string> name, Func<string> tooltip = null, string fieldId = null);
+
+
+        /****
+        ** Multi-page management
+        ****/
+        /// <summary>Start a new page in the mod's config UI, or switch to that page if it already exists. All options registered after this will be part of that page.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="pageId">The unique page ID.</param>
+        /// <param name="pageTitle">The page title shown in its UI, or <c>null</c> to show the <paramref name="pageId"/> value.</param>
+        /// <remarks>You must also call <see cref="AddPageLink"/> to make the page accessible. This is only needed to set up a multi-page config UI. If you don't call this method, all options will be part of the mod's main config UI instead.</remarks>
+        void AddPage(IManifest mod, string pageId, Func<string> pageTitle = null);
+
+        /// <summary>Add a link to a page added via <see cref="AddPage"/> at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="pageId">The unique ID of the page to open when the link is clicked.</param>
+        /// <param name="text">The link text shown in the form.</param>
+        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the link, or <c>null</c> to disable the tooltip.</param>
+        void AddPageLink(IManifest mod, string pageId, Func<string> text, Func<string> tooltip = null);
+
+
+        /****
+        ** Advanced
+        ****/
+        /// <summary>Add an option at the current position in the form using custom rendering logic.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="name">The label text to show in the form.</param>
+        /// <param name="draw">Draw the option in the config UI. This is called with the sprite batch being rendered and the pixel position at which to start drawing.</param>
+        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field, or <c>null</c> to disable the tooltip.</param>
+        /// <param name="beforeMenuOpened">A callback raised just before the menu containing this option is opened.</param>
+        /// <param name="beforeSave">A callback raised before the form's current values are saved to the config (i.e. before the <c>save</c> callback passed to <see cref="Register"/>).</param>
+        /// <param name="afterSave">A callback raised after the form's current values are saved to the config (i.e. after the <c>save</c> callback passed to <see cref="Register"/>).</param>
+        /// <param name="beforeReset">A callback raised before the form is reset to its default values (i.e. before the <c>reset</c> callback passed to <see cref="Register"/>).</param>
+        /// <param name="afterReset">A callback raised after the form is reset to its default values (i.e. after the <c>reset</c> callback passed to <see cref="Register"/>).</param>
+        /// <param name="beforeMenuClosed">A callback raised just before the menu containing this option is closed.</param>
+        /// <param name="height">The pixel height to allocate for the option in the form, or <c>null</c> for a standard input-sized option. This is called and cached each time the form is opened.</param>
+        /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
+        /// <remarks>The custom logic represented by the callback parameters is responsible for managing its own state if needed. For example, you can store state in a static field or use closures to use a state variable.</remarks>
+        void AddComplexOption(IManifest mod, Func<string> name, Action<SpriteBatch, Vector2> draw, Func<string> tooltip = null, Action beforeMenuOpened = null, Action beforeSave = null, Action afterSave = null, Action beforeReset = null, Action afterReset = null, Action beforeMenuClosed = null, Func<int> height = null, string fieldId = null);
+
+        /// <summary>Set whether the options registered after this point can only be edited from the title screen.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="titleScreenOnly">Whether the options can only be edited from the title screen.</param>
+        /// <remarks>This lets you have different values per-field. Most mods should just set it once in <see cref="Register"/>.</remarks>
+        void SetTitleScreenOnlyForNextOptions(IManifest mod, bool titleScreenOnly);
+
+        /// <summary>Register a method to notify when any option registered by this mod is edited through the config UI.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="onChange">The method to call with the option's unique field ID and new value.</param>
+        /// <remarks>Options use a randomized ID by default; you'll likely want to specify the <c>fieldId</c> argument when adding options if you use this.</remarks>
+        void OnFieldChanged(IManifest mod, Action<string, object> onChange);
+
+        /// <summary>Open the config UI for a specific mod.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        void OpenModMenu(IManifest mod);
+
+        /// <summary>Get the currently-displayed mod config menu, if any.</summary>
+        /// <param name="mod">The manifest of the mod whose config menu is being shown, or <c>null</c> if not applicable.</param>
+        /// <param name="page">The page ID being shown for the current config menu, or <c>null</c> if not applicable. This may be <c>null</c> even if a mod config menu is shown (e.g. because the mod doesn't have pages).</param>
+        /// <returns>Returns whether a mod config menu is being shown.</returns>
+        bool TryGetCurrentMenu(out IManifest mod, out string page);
+
+        /// <summary>Remove a mod from the config UI and delete all its options and pages.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        void Unregister(IManifest mod);
+    }
+}

--- a/AnimalSitter/manifest.json
+++ b/AnimalSitter/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "Animal Sitter LTS",
   "Author": "oliver",
-  "Version": "2.0.5",
+  "Version": "2.1.0",
   "Description": "Long Term Support Mod Version for Animal Sitter Mod. Let someone else pet all those pesky animals!",
   "UniqueID": "oliver.AnimalSitterLTS",
   "EntryDll": "AnimalSitter.dll",


### PR DESCRIPTION
This PR will fix #7 

Supported Config:

```json
{
  "KeyBind": "O",
  "GrowUpEnabled": false,
  "MaxHappinessEnabled": false,
  "MaxFullnessEnabled": false,
  "HarvestEnabled": true,
  "PettingEnabled": true,
  "MaxFriendshipEnabled": false,
  "CostPerAction": 25,
  "EnableMessages": true,
  "TakeTrufflesFromPigs": false,
}
```

Currently Only support config change at title screen.